### PR TITLE
Refactored proposed mapping schema to a type based form iso root-elem…

### DIFF
--- a/schema/xsd/merged-syntax.xsd
+++ b/schema/xsd/merged-syntax.xsd
@@ -1,176 +1,148 @@
 <!-- XML Schema for the VODML lite mapping L. Michel 06/2020 -->
 <!-- MIVOT schema for the record -->
-<xs:schema attributeFormDefault="unqualified" elementFormDefault="qualified" version="1.1"
-	xmlns:xs="http://www.w3.org/2001/XMLSchema">
+<!-- 
+GL 2021-07-23: Refactoring towards using type definitions rather than global elements. 
+  Following VOTable v 1.11 refactoring from 23-May-2006 
+-->
+<!-- ======================= -->
+<xs:schema attributeFormDefault="unqualified" elementFormDefault="qualified" version="1.1" xmlns:xs="http://www.w3.org/2001/XMLSchema">
 
-	<!-- Top level structure of the mapping block -->
-	<xs:element name="VODML">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element ref="MODEL" minOccurs="1" maxOccurs="unbounded" />
-				<xs:element ref="GLOBALS" minOccurs="1" maxOccurs="1" />
-				<xs:element ref="TEMPLATES" minOccurs="0" maxOccurs="unbounded" />
-			</xs:sequence>
-		</xs:complexType>
-	</xs:element>
+  <!-- Top level structure of the mapping block -->
+  <xs:element name="VODML">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="MODEL" type="Model" minOccurs="1" maxOccurs="unbounded" />
+        <xs:element name="GLOBALS" type="Globals" minOccurs="0" maxOccurs="1" /> 
+        <xs:element name="TEMPLATES" type="Templates" minOccurs="0" maxOccurs="unbounded" />
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
 
+  <!-- Declaration of one used model -->
+  <xs:complexType name="Model">
+    <xs:attribute name="name" type="xs:string" />
+    <xs:attribute name="url" type="xs:anyURI" />
+    <xs:assert test="@name != ''" />
+    <xs:assert test="if (@url) then (@url != '') else true()  " />
+  </xs:complexType>
 
-	<!-- Mapping of the data contained in a particular table -->
-	<xs:element name="TEMPLATES">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element ref="WHERE" minOccurs="0" maxOccurs="unbounded" />
-				<xs:choice>
-					<xs:element ref="INSTANCE" minOccurs="0" maxOccurs="unbounded" />
-				</xs:choice>
-			</xs:sequence>
+  <!-- Mapping of the data that have a global scope (e.g. frames) -->
+  <xs:complexType name="Globals">
+    <xs:all>
+      <xs:element name="INSTANCE" type="Instance" minOccurs="0" maxOccurs="unbounded" />
+      <xs:element name="COLLECTION" type="Collection" minOccurs="0" maxOccurs="unbounded" />
+    </xs:all>
+  </xs:complexType>
 
-			<xs:attribute type="xs:string" name="tableref" use="required" />
-			<xs:assert test="@tableref != ''" />
-		</xs:complexType>
-	</xs:element>
-
-	<!-- Declaration of one used model -->
-	<xs:element name="MODEL">
-		<xs:complexType>
-			<xs:attribute type="xs:string" name="name" />
-			<xs:attribute type="xs:string" name="url" />
-			<xs:assert test="@name != ''" />
-			<xs:assert test="if (@url) then (@url != '') else true()  " />
-		</xs:complexType>
-	</xs:element>
-
-	<!-- Mapping of the data that have a global scope (e.g. frames) -->
-	<xs:element name="GLOBALS">
-		<xs:complexType>
-			<xs:all>
-				<xs:element ref="INSTANCE" minOccurs="0" maxOccurs="unbounded" />
-				<xs:element ref="COLLECTION" minOccurs="0" maxOccurs="unbounded" />
-			</xs:all>
-		</xs:complexType>
-	</xs:element>
-
-	<!-- Mapping of either a Datatype or an Objecttype -->
-	<xs:element name="INSTANCE">
-
-		<xs:complexType>
-			<xs:sequence>
-				<xs:choice maxOccurs="1">
-					<xs:element ref="PRIMARY_KEY" minOccurs="0" />
-				</xs:choice>
-				<xs:choice maxOccurs="unbounded">
-                    <xs:element ref="REFERENCE" minOccurs="0" />
-                    <xs:element ref="ATTRIBUTE" minOccurs="0" />
-					<xs:element ref="INSTANCE" minOccurs="0" />
-					<xs:element ref="COLLECTION" minOccurs="0" />
-				</xs:choice>
-			</xs:sequence>
-			<xs:attribute type="xs:string" name="dmrole" use="required"/>
-			<xs:attribute type="xs:string" name="dmtype" use="required"/>
-			<xs:attribute type="xs:string" name="ID" />
-            <xs:assert test="(not(./@ID) and  @dmrole != '') or @ID != ''  " />
-            <xs:assert test=" @dmtype != '' " />
-			<xs:assert test="if (@ID) then ( @ID != '') else true()  " />
-		</xs:complexType>
-	</xs:element>
-
-	<!-- Atomic attribute -->
-	<xs:element name="ATTRIBUTE">
-		<xs:complexType>
-			<xs:attribute type="xs:string" name="dmrole"  use="required"/>
-			<xs:attribute type="xs:string" name="dmtype"  use="required" />
-			<xs:attribute type="xs:string" name="ref" />
-			<xs:attribute type="xs:string" name="value" />
-			<xs:assert test="(not(./@ref) and ./@value) or (not(./@value) and ./@ref) or (./@value and ./@ref)" />
-			<xs:assert test="if (@ref) then (@ref != '') else true()  " />
-			<xs:assert test="@dmrole != '' and @dmtype != ''  " />
-		</xs:complexType>
-	</xs:element>
-
-	<!-- Data list mapping block -->
-	<xs:element name="COLLECTION">
-		<xs:complexType>
-			<xs:all>
-			    <xs:element ref="REFERENCE" minOccurs="0" maxOccurs="unbounded"/>
-				<xs:element ref="INSTANCE" minOccurs="0" maxOccurs="unbounded" />
-				<xs:element ref="ATTRIBUTE" minOccurs="0" maxOccurs="unbounded" />
-				<xs:element ref="COLLECTION" minOccurs="0" maxOccurs="unbounded" />
-				<xs:element ref="JOIN" minOccurs="0" maxOccurs="1" />
-			</xs:all>
-			<xs:attribute type="xs:string" name="dmrole" use="required" />
-			<xs:attribute type="xs:string" name="size" />
-			<xs:attribute type="xs:string" name="ID" />
-			<xs:assert test="./@dmrole" />
-			<xs:assert test="if (@ID) then ( @ID != '') else true()  " />
-			<xs:assert test="not(@ID) and @dmrole != '' or  @ID != ''" />
-
-			<xs:assert
-				test="((count(./JOIN) eq 1 and count(./INSTANCE) eq 0 and count(./COLLECTION) eq 0 and count(./REFERENCE) eq 0)  or count(./JOIN) eq 0)" />
-		</xs:complexType>
-	</xs:element>
+  <!-- Mapping of the data contained in a particular table -->
+  <xs:complexType name="Templates">
+    <xs:sequence>
+      <xs:element name="WHERE" type="Where" minOccurs="0" maxOccurs="unbounded" /> 
+      <xs:element name="INSTANCE" type="Instance" minOccurs="0" maxOccurs="unbounded" />
+    </xs:sequence>
+    <xs:attribute type="xs:string" name="tableref" use="required" />
+    <xs:assert test="@tableref != ''" />
+  </xs:complexType>
 
 
-    <xs:element name="REFERENCE">
-        <xs:complexType>
-            <xs:sequence>
-                <xs:element ref="FOREIGN_KEY" minOccurs="0" maxOccurs="1" />
-            </xs:sequence>
-            <xs:attribute type="xs:string" name="dmrole" use="required"/>
-            <xs:attribute type="xs:string" name="tableref" />
-            <xs:attribute type="xs:string" name="dmref" />
-            <xs:assert test="if (./@tableref) then  @tableref != '' else true()" />
-            <xs:assert test="if (./@dmref) then  @dmref != '' else true()" />
-            <xs:assert test="(./@dmref and not(./@tableref)) or (not(./@dmref) and ./@tableref)" />
-            <xs:assert
-                test="((count(./FOREIGN_KEY) eq 1 and ./@tableref and not(./@dmref))  or (count(./FOREIGN_KEY) eq 0 and not(./@tableref) and ./@dmref))" />
-            
-        </xs:complexType>
-    </xs:element>
+  <!-- Mapping of either a Datatype or an Objecttype -->
+  <xs:complexType name="Instance">
+    <xs:sequence>
+      <xs:choice maxOccurs="1">
+        <xs:element name="PRIMARY_KEY" type="PrimaryKey" minOccurs="0" />
+      </xs:choice> <!-- can this now be an xs:all -->
+      <xs:choice maxOccurs="unbounded">
+        <xs:element name="REFERENCE" type="Reference" minOccurs="0" />
+        <xs:element name="ATTRIBUTE" type="Attribute" minOccurs="0" />
+        <xs:element name="INSTANCE" type="Instance" minOccurs="0" /> 
+        <xs:element name="COLLECTION" type="Collection" minOccurs="0" />
+      </xs:choice>
+    </xs:sequence>
+    <xs:attribute type="xs:string" name="dmrole" use="optional" /> 
+    <xs:attribute type="xs:string" name="dmtype" use="required" /> 
+    <xs:attribute type="xs:string" name="ID" />  
+    <xs:assert test="(not(./@ID) and  @dmrole != '') or @ID != ''  " />
+    <xs:assert test=" @dmtype != '' " />
+    <xs:assert test="if (@ID) then ( @ID != '') else true()  " />
+  </xs:complexType>
 
-	<!-- Join with another table One instance created for joined row of the secondary table -->
-	<xs:element name="JOIN">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:element ref="WHERE" minOccurs="0" maxOccurs="unbounded" />
-			</xs:sequence>
-			<xs:attribute type="xs:string" name="tableref" />
-			<xs:attribute type="xs:string" name="dmref" />
-			<xs:assert test="if (./@tableref) then  @tableref != '' else true()" />
-			<xs:assert test="if (./@dmref) then  @dmref != '' else true()" />
-			<xs:assert test="(./@dmref and not(./@tableref)) or (not(./@dmref) and ./@tableref)" />
-		</xs:complexType>
-	</xs:element>
+  <!-- Atomic attribute -->
+  <xs:complexType name="Attribute">
+    <xs:attribute type="xs:string" name="dmrole" use="required" />
+    <xs:attribute type="xs:string" name="dmtype" use="required" />
+    <xs:attribute type="xs:string" name="ref" />
+    <xs:attribute type="xs:string" name="value" />
+    <xs:assert test="(not(./@ref) and ./@value) or (not(./@value) and ./@ref) or (./@value and ./@ref)" /> 
+    <xs:assert test="if (@ref) then (@ref != '') else true()  " />  
+    <xs:assert test="@dmrole != '' and @dmtype != ''  " />  
+  </xs:complexType>
 
-	<!-- Select table rows with value of the column @ref = @value -->
-	<xs:element name="WHERE">
-		<xs:complexType>
-			<xs:attribute type="xs:string" name="foreignkey" />
-			<xs:attribute type="xs:string" name="primarykey" />
-			<xs:attribute type="xs:string" name="value" />
-			<xs:assert
-				test="(./@foreignkey and ./@primarykey and not(@value)) or (./@foreignkey and not(./@primarykey) and @value)  or (not(./@foreignkey) and ./@primarykey and @value)" />
-			<xs:assert test="if (./@foreignkey) then  @foreignkey != '' else true()" />
-			<xs:assert test="if (./@primarykey) then  @primarykey != '' else true()" />
-		</xs:complexType>
-	</xs:element>
+  <!-- Data list mapping block -->
+  <xs:complexType name="Collection"> 
+    <xs:all>
+      <xs:element name="REFERENCE" type="Reference" minOccurs="0" maxOccurs="unbounded" />
+      <xs:element name="INSTANCE" type="Instance" minOccurs="0" maxOccurs="unbounded" />
+      <xs:element name="ATTRIBUTE" type="Attribute" minOccurs="0" maxOccurs="unbounded" />
+      <xs:element name="COLLECTION" type="Collection" minOccurs="0" maxOccurs="unbounded" />
+      <xs:element name="JOIN" type="Join" minOccurs="0" maxOccurs="1" />
+    </xs:all>
+    <xs:attribute type="xs:string" name="dmrole" use="required" />
+    <xs:attribute type="xs:string" name="size" />  
+    <xs:attribute type="xs:string" name="ID" />
+    <xs:assert test="./@dmrole" />
+    <xs:assert test="if (@ID) then ( @ID != '') else true()  " />
+    <xs:assert test="not(@ID) and @dmrole != '' or  @ID != ''" />
 
-    <xs:element name="PRIMARY_KEY">
-        <xs:complexType>
-            <xs:attribute type="xs:string" name="ref" />
-            <xs:attribute type="xs:string" name="dmtype" />
-            <xs:attribute type="xs:string" name="value" />
-            <xs:assert test="./@ref  or ./@value " />
-            <xs:assert test="@dmtype != '' " />
-            <xs:assert test="if (./@ref) then  @ref != '' else true()" />
-        </xs:complexType>
-    </xs:element>
-    
-    <xs:element name="FOREIGN_KEY">
-        <xs:complexType>
-            <xs:attribute type="xs:string" name="ref" use="required"/>
-            <xs:assert test="@ref != ''" />
-        </xs:complexType>
-    </xs:element>
+    <xs:assert test="((count(./JOIN) eq 1 and count(./INSTANCE) eq 0 and count(./COLLECTION) eq 0 and count(./REFERENCE) eq 0)  or count(./JOIN) eq 0)" />
+  </xs:complexType>
 
+  <xs:complexType name="Reference">
+    <xs:sequence>
+      <xs:element name="FOREIGN_KEY" type="ForeignKey" minOccurs="0" maxOccurs="1" />
+    </xs:sequence>
+    <xs:attribute type="xs:string" name="dmrole" use="required" />
+    <xs:attribute type="xs:string" name="tableref" />
+    <xs:attribute type="xs:string" name="dmref" />
+    <xs:assert test="if (./@tableref) then  @tableref != '' else true()" />
+    <xs:assert test="if (./@dmref) then  @dmref != '' else true()" />
+    <xs:assert test="(./@dmref and not(./@tableref)) or (not(./@dmref) and ./@tableref)" />
+    <xs:assert test="((count(./FOREIGN_KEY) eq 1 and ./@tableref and not(./@dmref))  or (count(./FOREIGN_KEY) eq 0 and not(./@tableref) and ./@dmref))" />
+  </xs:complexType>
+
+  <!-- Join with another table One instance created for joined row of the secondary table -->
+  <xs:complexType name="Join">
+    <xs:sequence>
+      <xs:element name="WHERE" type="Where" minOccurs="0" maxOccurs="unbounded" />
+    </xs:sequence>
+    <xs:attribute type="xs:string" name="tableref" />
+    <xs:attribute type="xs:string" name="dmref" />
+    <xs:assert test="if (./@tableref) then  @tableref != '' else true()" />
+    <xs:assert test="if (./@dmref) then  @dmref != '' else true()" />
+    <xs:assert test="(./@dmref and not(./@tableref)) or (not(./@dmref) and ./@tableref)" />
+  </xs:complexType>
+
+  <!-- Select table rows with value of the column @ref = @value -->
+  <xs:complexType name="Where">
+    <xs:attribute type="xs:string" name="foreignkey" />
+    <xs:attribute type="xs:string" name="primarykey" />
+    <xs:attribute type="xs:string" name="value" />
+    <xs:assert test="(./@foreignkey and ./@primarykey and not(@value)) or (./@foreignkey and not(./@primarykey) and @value)  or (not(./@foreignkey) and ./@primarykey and @value)" />
+    <xs:assert test="if (./@foreignkey) then  @foreignkey != '' else true()" />
+    <xs:assert test="if (./@primarykey) then  @primarykey != '' else true()" />
+  </xs:complexType>
+
+  <xs:complexType name="PrimaryKey">
+    <xs:attribute type="xs:string" name="ref" />
+    <xs:attribute type="xs:string" name="dmtype" />
+    <xs:attribute type="xs:string" name="value" />
+    <xs:assert test="./@ref  or ./@value " />
+    <xs:assert test="@dmtype != '' " />
+    <xs:assert test="if (./@ref) then  @ref != '' else true()" />
+  </xs:complexType>
+
+  <xs:complexType name="ForeignKey">
+    <xs:attribute type="xs:string" name="ref" use="required" />
+    <xs:assert test="@ref != ''" />
+  </xs:complexType>
 
 </xs:schema>


### PR DESCRIPTION
…ent + ref.

This follows e.g. 23-May-2006 refactoring of VOTable version 1.11.
Proposed usage in VOTable through an xs:any requires that this schema does define its own root element.