### PR TITLE
Instance in collection

### DIFF
--- a/schema/validation/snippets/test_3_ko_3.10.xml
+++ b/schema/validation/snippets/test_3_ko_3.10.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<dm-mapping:VODML xmlns:dm-mapping="http://www.ivoa.net/xml/merged-syntax">
+
+	<dm-mapping:MODEL name="model" url="http://aaaaaa" />
+
+	<!-- Test Case 3.8: no @ID in GLOBALS children -->
+	<dm-mapping:GLOBALS>
+        <dm-mapping:COLLECTION  dmrole=""/>
+ 	</dm-mapping:GLOBALS>
+
+</dm-mapping:VODML>

--- a/schema/validation/snippets/test_3_ko_3.6.xml
+++ b/schema/validation/snippets/test_3_ko_3.6.xml
@@ -7,11 +7,11 @@
 
 	<!-- Test Case 3.6: unexpected subnode -->
 	<dm-mapping:GLOBALS >
-		<dm-mapping:COLLECTION dmrole="aaaaa">
+		<dm-mapping:COLLECTION>
 		    <dm-mapping:ATTRIBUTE dmrole="dmrole" dmtype="dmtype" value="aa" />
 		</dm-mapping:COLLECTION>
 		<dm-mapping:REFERENCE dmrole="aaaa" ref="_zzz" />
-		<dm-mapping:INSTANCE dmrole="aaaa" dmtype="fffff" />
+		<dm-mapping:INSTANCE  dmtype="fffff" />
 	</dm-mapping:GLOBALS>
 
 </dm-mapping:VODML>

--- a/schema/validation/snippets/test_3_ko_3.7.xml
+++ b/schema/validation/snippets/test_3_ko_3.7.xml
@@ -5,7 +5,7 @@
 
 	<dm-mapping:MODEL name="model" url="http://aaaaaa" />
 
-	<!-- Test Case 3.3: COLLECTION optional -->
+	<!-- Test Case 3.7: GLOBALS/INSTANCE with a @dmrole -->
 	<dm-mapping:GLOBALS >
 		<dm-mapping:INSTANCE dmrole="aaaa" dmtype="fffff" />
 	</dm-mapping:GLOBALS>

--- a/schema/validation/snippets/test_3_ko_3.7.xml
+++ b/schema/validation/snippets/test_3_ko_3.7.xml
@@ -5,11 +5,9 @@
 
 	<dm-mapping:MODEL name="model" url="http://aaaaaa" />
 
-	<!-- Test Case 3.2: INSTANCE optional -->
+	<!-- Test Case 3.3: COLLECTION optional -->
 	<dm-mapping:GLOBALS >
-		<dm-mapping:COLLECTION ID="adaas" dmrole="">
-		    <dm-mapping:ATTRIBUTE dmrole="dmrole" dmtype="dmtype" value="aa" />
-		</dm-mapping:COLLECTION>
+		<dm-mapping:INSTANCE dmrole="aaaa" dmtype="fffff" />
 	</dm-mapping:GLOBALS>
 
 </dm-mapping:VODML>

--- a/schema/validation/snippets/test_3_ko_3.9.xml
+++ b/schema/validation/snippets/test_3_ko_3.9.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<dm-mapping:VODML xmlns:dm-mapping="http://www.ivoa.net/xml/merged-syntax">
+
+	<dm-mapping:MODEL name="model" url="http://aaaaaa" />
+
+	<!-- Test Case 3.8: @role in GLOBALS children -->
+	<dm-mapping:GLOBALS>
+        <dm-mapping:COLLECTION ID="asdasdas" dmrole="dfgdfd"/>
+ 	</dm-mapping:GLOBALS>
+
+</dm-mapping:VODML>

--- a/schema/validation/snippets/test_3_ko_3.9.xml
+++ b/schema/validation/snippets/test_3_ko_3.9.xml
@@ -4,7 +4,7 @@
 
 	<dm-mapping:MODEL name="model" url="http://aaaaaa" />
 
-	<!-- Test Case 3.8: @role in GLOBALS children -->
+	<!-- Test Case 3.9: @role in GLOBALS children -->
 	<dm-mapping:GLOBALS>
         <dm-mapping:COLLECTION ID="asdasdas" dmrole="dfgdfd"/>
  	</dm-mapping:GLOBALS>

--- a/schema/validation/snippets/test_3_ok_3.1.xml
+++ b/schema/validation/snippets/test_3_ok_3.1.xml
@@ -7,10 +7,10 @@
 
 	<!-- Test Case 3.1: basic instance, all subnodes -->
 	<dm-mapping:GLOBALS >
-		<dm-mapping:COLLECTION dmrole="aaaaa">
+		<dm-mapping:COLLECTION ID="sadas" dmrole="">
 		    <dm-mapping:ATTRIBUTE dmrole="dmrole" dmtype="dmtype" value="aa" />
 		</dm-mapping:COLLECTION>
-		<dm-mapping:INSTANCE dmrole="aaaa" dmtype="fffff" />
+		<dm-mapping:INSTANCE ID="ssdfsfds" dmrole="" dmtype="fffff" />
 	</dm-mapping:GLOBALS>
 
 </dm-mapping:VODML>

--- a/schema/validation/snippets/test_3_ok_3.1.xml
+++ b/schema/validation/snippets/test_3_ok_3.1.xml
@@ -8,7 +8,7 @@
 	<!-- Test Case 3.1: basic instance, all subnodes -->
 	<dm-mapping:GLOBALS >
 		<dm-mapping:COLLECTION ID="sadas" dmrole="">
-		    <dm-mapping:ATTRIBUTE dmrole="dmrole" dmtype="dmtype" value="aa" />
+		    <dm-mapping:ATTRIBUTE dmtype="dmtype" value="aa" />
 		</dm-mapping:COLLECTION>
 		<dm-mapping:INSTANCE ID="ssdfsfds" dmrole="" dmtype="fffff" />
 	</dm-mapping:GLOBALS>

--- a/schema/validation/snippets/test_3_ok_3.2.xml
+++ b/schema/validation/snippets/test_3_ok_3.2.xml
@@ -8,7 +8,7 @@
 	<!-- Test Case 3.2: INSTANCE optional -->
 	<dm-mapping:GLOBALS >
 		<dm-mapping:COLLECTION ID="adaas" dmrole="">
-		    <dm-mapping:ATTRIBUTE dmrole="dmrole" dmtype="dmtype" value="aa" />
+		    <dm-mapping:ATTRIBUTE dmtype="dmtype" value="aa" />
 		</dm-mapping:COLLECTION>
 	</dm-mapping:GLOBALS>
 

--- a/schema/validation/snippets/test_3_ok_3.3.xml
+++ b/schema/validation/snippets/test_3_ok_3.3.xml
@@ -7,7 +7,7 @@
 
 	<!-- Test Case 3.3: COLLECTION optional -->
 	<dm-mapping:GLOBALS >
-		<dm-mapping:INSTANCE dmrole="aaaa" dmtype="fffff" />
+		<dm-mapping:INSTANCE ID="sss" dmrole="" dmtype="fffff" />
 	</dm-mapping:GLOBALS>
 
 </dm-mapping:VODML>

--- a/schema/validation/snippets/test_3_ok_3.4.xml
+++ b/schema/validation/snippets/test_3_ok_3.4.xml
@@ -1,24 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<dm-mapping:VODML
-	xmlns:dm-mapping="http://www.ivoa.net/xml/merged-syntax">
+<dm-mapping:VODML xmlns:dm-mapping="http://www.ivoa.net/xml/merged-syntax">
 
 	<dm-mapping:MODEL name="model" url="http://aaaaaa" />
 
 	<!-- Test Case 3.4: allows multiple instances of each subnode, in any order -->
-	<dm-mapping:GLOBALS >
-				<dm-mapping:COLLECTION dmrole="aaaaa">
-		    <dm-mapping:ATTRIBUTE dmrole="dmrole" dmtype="dmtype" value="aa" />
+	<dm-mapping:GLOBALS>
+		<dm-mapping:COLLECTION ID="asdasdas" dmrole="">
+			<dm-mapping:ATTRIBUTE dmrole="dmrole" dmtype="dmtype" value="aa" />
 		</dm-mapping:COLLECTION>
-		<dm-mapping:INSTANCE dmrole="aaaa" dmtype="fffff" />
-		<dm-mapping:INSTANCE dmrole="bbbb" dmtype="fffff" />
-				<dm-mapping:COLLECTION dmrole="aaaaa">
-		    <dm-mapping:ATTRIBUTE dmrole="dmrole" dmtype="dmtype" value="aa" />
+		<dm-mapping:INSTANCE ID="sadasdas" dmrole="" dmtype="fffff" />
+		<dm-mapping:INSTANCE ID="sadasdas" dmrole="" dmtype="fffff" />
+		<dm-mapping:COLLECTION ID="asdasdasd" dmrole="">
+			<dm-mapping:ATTRIBUTE dmrole="dmrole" dmtype="dmtype" value="aa" />
 		</dm-mapping:COLLECTION>
-				<dm-mapping:COLLECTION dmrole="aaaaa">
-		    <dm-mapping:ATTRIBUTE dmrole="dmrole" dmtype="dmtype" value="aa" />
+		<dm-mapping:COLLECTION ID="assadsad" dmrole="">
+			<dm-mapping:ATTRIBUTE dmrole="dmrole" dmtype="dmtype" value="aa" />
 		</dm-mapping:COLLECTION>
-		<dm-mapping:INSTANCE dmrole="cccc" dmtype="fffff" />
+		<dm-mapping:INSTANCE ID="sadasdas" dmrole="" dmtype="fffff" />
 	</dm-mapping:GLOBALS>
 
 </dm-mapping:VODML>

--- a/schema/validation/snippets/test_3_ok_3.4.xml
+++ b/schema/validation/snippets/test_3_ok_3.4.xml
@@ -7,15 +7,15 @@
 	<!-- Test Case 3.4: allows multiple instances of each subnode, in any order -->
 	<dm-mapping:GLOBALS>
 		<dm-mapping:COLLECTION ID="asdasdas" dmrole="">
-			<dm-mapping:ATTRIBUTE dmrole="dmrole" dmtype="dmtype" value="aa" />
+			<dm-mapping:ATTRIBUTE  dmtype="dmtype" value="aa" />
 		</dm-mapping:COLLECTION>
 		<dm-mapping:INSTANCE ID="sadasdas" dmrole="" dmtype="fffff" />
 		<dm-mapping:INSTANCE ID="sadasdas" dmrole="" dmtype="fffff" />
 		<dm-mapping:COLLECTION ID="asdasdasd" dmrole="">
-			<dm-mapping:ATTRIBUTE dmrole="dmrole" dmtype="dmtype" value="aa" />
+			<dm-mapping:ATTRIBUTE dmtype="dmtype" value="aa" />
 		</dm-mapping:COLLECTION>
 		<dm-mapping:COLLECTION ID="assadsad" dmrole="">
-			<dm-mapping:ATTRIBUTE dmrole="dmrole" dmtype="dmtype" value="aa" />
+			<dm-mapping:ATTRIBUTE  dmtype="dmtype" value="aa" />
 		</dm-mapping:COLLECTION>
 		<dm-mapping:INSTANCE ID="sadasdas" dmrole="" dmtype="fffff" />
 	</dm-mapping:GLOBALS>

--- a/schema/validation/snippets/test_3_ok_3.8.xml
+++ b/schema/validation/snippets/test_3_ok_3.8.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<dm-mapping:VODML xmlns:dm-mapping="http://www.ivoa.net/xml/merged-syntax">
+
+	<dm-mapping:MODEL name="model" url="http://aaaaaa" />
+
+	<!-- Test Case 3.8: no @role but @ID in GLOBALS children -->
+	<dm-mapping:GLOBALS>
+        <dm-mapping:COLLECTION ID="asdasdas" dmrole=""/>
+        <dm-mapping:COLLECTION ID="asdasdas"/>
+        <dm-mapping:INSTANCE ID="asdasdas" dmrole="" dmtype="sdsdfs"/>
+        <dm-mapping:INSTANCE ID="asdasdas" dmtype="sdsdfs"/>
+	</dm-mapping:GLOBALS>
+
+</dm-mapping:VODML>

--- a/schema/validation/snippets/test_4_ko_4.5.xml
+++ b/schema/validation/snippets/test_4_ko_4.5.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<dm-mapping:VODML
+	xmlns:dm-mapping="http://www.ivoa.net/xml/merged-syntax">
+
+	<dm-mapping:MODEL name="model" url="http://aaaaaa" />
+    <dm-mapping:GLOBALS />
+	<!-- Test Case 4.5: INSTANCE without required @dmrole -->
+	<dm-mapping:TEMPLATES tableref="fgdgfddf">
+		<dm-mapping:INSTANCE ID="dsadas" dmrole="" />
+	</dm-mapping:TEMPLATES>
+
+</dm-mapping:VODML>

--- a/schema/validation/snippets/test_5_ko_5.14.xml
+++ b/schema/validation/snippets/test_5_ko_5.14.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<dm-mapping:VODML
+	xmlns:dm-mapping="http://www.ivoa.net/xml/merged-syntax">
+
+    <dm-mapping:MODEL name="model" />
+    <dm-mapping:GLOBALS />
+	<dm-mapping:TEMPLATES tableref="fgdgfddf">
+
+		<!-- Test Case 5.14: INSTACE children without role -->
+		<dm-mapping:INSTANCE ID="_ref1" dmrole="aaaa" dmtype="fffff">
+			<dm-mapping:INSTANCE ID="SSSS" dmtype="fffff" />
+		</dm-mapping:INSTANCE>
+		
+	</dm-mapping:TEMPLATES>
+</dm-mapping:VODML>

--- a/schema/validation/snippets/test_5_ok.xml
+++ b/schema/validation/snippets/test_5_ok.xml
@@ -69,6 +69,14 @@
 			<dm-mapping:REFERENCE dmrole="aaaa" dmref="fffff"/>
 			<dm-mapping:ATTRIBUTE dmrole="aaaa" dmtype="fffff" value="eeee"/>
 		</dm-mapping:INSTANCE>
+		
+        <dm-mapping:INSTANCE dmrole="parent" dmtype="fffff">
+		    <dm-mapping:COLLECTION dmrole="items">
+		        <dm-mapping:INSTANCE dmrole="" dmtype="fffff">
+                    <dm-mapping:PRIMARY_KEY dmtype="fffff" value="tttt" />
+               </dm-mapping:INSTANCE>
+		    </dm-mapping:COLLECTION>
+		</dm-mapping:INSTANCE>
 
 	</dm-mapping:TEMPLATES>
 </dm-mapping:VODML>

--- a/schema/validation/snippets/test_8_ko_8.13.xml
+++ b/schema/validation/snippets/test_8_ko_8.13.xml
@@ -8,8 +8,8 @@
 
 	        <!-- Test Case 8.13: mixed subnode sets -->
 	        <!--   * allow (A), (R) or (I,J,C) only    -->
-		<dm-mapping:COLLECTION dmrole="role">
-			<dm-mapping:ATTRIBUTE dmrole="A.b" dmtype="model:elem" value="foo" />
+		<dm-mapping:COLLECTION>
+			<dm-mapping:ATTRIBUTE  dmtype="model:elem" value="foo" />
 			<dm-mapping:INSTANCE ID="_ds1" dmrole="" dmtype="ds:experiment.ObsDataset" />
 		</dm-mapping:COLLECTION>
 

--- a/schema/validation/snippets/test_8_ko_8.4.xml
+++ b/schema/validation/snippets/test_8_ko_8.4.xml
@@ -7,7 +7,7 @@
 	<dm-mapping:GLOBALS>
 
 		<!-- Test Case 8.4: ID must not be empty. -->
-		<dm-mapping:COLLECTION ID="" dmrole="abc" />
+		<dm-mapping:COLLECTION ID="" />
 
 	</dm-mapping:GLOBALS>
 	      

--- a/schema/validation/snippets/test_8_ko_8.6.xml
+++ b/schema/validation/snippets/test_8_ko_8.6.xml
@@ -6,7 +6,7 @@
 	<dm-mapping:MODEL name="model" url="http://aaaaaa" />
 	<dm-mapping:GLOBALS>
 
-		<!-- Test Case 8.5: No role for COLLECTION/INSTANCE-->
+        <!-- Test Case 8.6: No role for COLLECTION/ATTRIBUTE-->
 		<dm-mapping:COLLECTION dmrole="">
             <dm-mapping:INSTANCE dmrole="a.f"/>
         </dm-mapping:COLLECTION>

--- a/schema/validation/snippets/test_8_ko_8.7.xml
+++ b/schema/validation/snippets/test_8_ko_8.7.xml
@@ -6,9 +6,9 @@
 	<dm-mapping:MODEL name="model" url="http://aaaaaa" />
 	<dm-mapping:GLOBALS>
 
-		<!-- Test Case 8.5: No role for COLLECTION/INSTANCE-->
+        <!-- Test Case 8.7: No role for COLLECTION/REFERENCE-->
 		<dm-mapping:COLLECTION dmrole="">
-            <dm-mapping:INSTANCE dmrole="a.f"/>
+            <dm-mapping:REFERENCE dmrole="a.f"/>
         </dm-mapping:COLLECTION>
 
 	</dm-mapping:GLOBALS>

--- a/schema/validation/snippets/test_8_ok.xml
+++ b/schema/validation/snippets/test_8_ok.xml
@@ -28,38 +28,38 @@
 	        <!-- Test Note 8: All subnodes are optional, with 2 sets which may be combined under 1 COLLECTION. -->
 	  
 	        <!-- Test Case 8.1: empty COLLECTION -->
-		<dm-mapping:COLLECTION ID="_ds1" dmrole="abc" />
+		<dm-mapping:COLLECTION ID="_ds1"  />
 
 		<!-- Test Case 8.2: ID optional, dmrole must not be blank -->
-		<dm-mapping:COLLECTION dmrole="role" />
+		<dm-mapping:COLLECTION ID="_ds1.5" />
 
 		<!-- Test Case 8.5: with ID, dmrole may be blank -->
-		<dm-mapping:COLLECTION ID="_ds2" dmrole="" />
+		<dm-mapping:COLLECTION ID="_ds2"  />
 
 		<!-- Test Case 8.6: COLLECTION of ATTRIBUTE -->
-		<dm-mapping:COLLECTION dmrole="A.b">
-			<dm-mapping:ATTRIBUTE dmrole="A.b" dmtype="model:elem" value="foo" />
+		<dm-mapping:COLLECTION ID="_ds3" >
+			<dm-mapping:ATTRIBUTE dmtype="model:elem" value="foo" />
 		</dm-mapping:COLLECTION>
 		
 		<!-- Test Case 8.7: COLLECTION of REFERENCE -->
-		<dm-mapping:COLLECTION dmrole="abc">
-			<dm-mapping:REFERENCE dmrole="A" dmref="_ref1" />
+		<dm-mapping:COLLECTION ID="_ds4">
+			<dm-mapping:REFERENCE dmref="_ref1" />
 		</dm-mapping:COLLECTION>
 
 		<!-- Test Case 8.8: COLLECTION of INSTANCE -->
-		<dm-mapping:COLLECTION ID="_ds3" dmrole="abc">
-			<dm-mapping:INSTANCE dmrole="A" dmtype="ds:experiment.ObsDataset" />
+		<dm-mapping:COLLECTION ID="_ds3" dmrole="">
+			<dm-mapping:INSTANCE dmrole="" dmtype="ds:experiment.ObsDataset" />
 		</dm-mapping:COLLECTION>
 
 		<!-- Test Case 8.9: COLLECTION of JOIN -->
-		<dm-mapping:COLLECTION dmrole="abc">
+		<dm-mapping:COLLECTION ID="_ds4">
 			<dm-mapping:JOIN tableref="Results" />
 		</dm-mapping:COLLECTION>
 
 		<!-- Test Case 8.10: COLLECTION of COLLECTION -->
 		<!--   Q: what is COLLECTION of COLLECTION for again? -->
-		<dm-mapping:COLLECTION dmrole="acb">
-			<dm-mapping:COLLECTION dmrole="def"/>
+		<dm-mapping:COLLECTION ID="acb">
+			<dm-mapping:COLLECTION dmrole=""/>
 		</dm-mapping:COLLECTION>
 
 		<!-- Test Case 8.11: COLLECTION of multiple (ATTRIBUTE|REFERENCE) subnodes, random order -->
@@ -67,21 +67,21 @@
 		<!--   A: content should not have a specified dmrole (is on container), however
 		          most of the allowed contents do not generally allow empty/missing dmrole -->
 		<!--   Q: should these be allowed in combination?                        -->
-		<dm-mapping:COLLECTION dmrole="role">
-			<dm-mapping:REFERENCE dmrole="A" dmref="_ref1" />
-			<dm-mapping:REFERENCE dmrole="A" dmref="_ref2" />
+		<dm-mapping:COLLECTION ID="id">
+			<dm-mapping:REFERENCE dmrole="" dmref="_ref1" />
+			<dm-mapping:REFERENCE dmrole="" dmref="_ref2" />
 		</dm-mapping:COLLECTION>
 
 		<!-- Test Case 8.12: COLLECTION of multiple (INSTANCE|JOIN|COLLECTION) subnodes, random order -->
-		<dm-mapping:COLLECTION dmrole="role">
-			<dm-mapping:INSTANCE dmrole="A" dmtype="ds:experiment.ObsDataset" />
-			<dm-mapping:COLLECTION dmrole="B">
-				<dm-mapping:INSTANCE dmrole="B.a" dmtype="ds:experiment.ObsDataset" />
+		<dm-mapping:COLLECTION ID="id">
+			<dm-mapping:INSTANCE dmrole="" dmtype="ds:experiment.ObsDataset" />
+			<dm-mapping:COLLECTION dmrole="">
+				<dm-mapping:INSTANCE dmrole="" dmtype="ds:experiment.ObsDataset" />
 			</dm-mapping:COLLECTION>
-			<dm-mapping:COLLECTION dmrole="C">
+			<dm-mapping:COLLECTION dmrole="">
 				<dm-mapping:JOIN tableref="Results" />
 			</dm-mapping:COLLECTION>
-			<dm-mapping:INSTANCE dmrole="D" dmtype="ds:experiment.ObsDataset" />
+			<dm-mapping:INSTANCE dmrole="" dmtype="ds:experiment.ObsDataset" />
 			<dm-mapping:JOIN tableref="MoreResults" />
 			<!-- allow multiple JOIN nodes.. to build a COLLECTION of instances from different tables -->
 			<dm-mapping:JOIN tableref="EvenMoreResults" />
@@ -89,8 +89,8 @@
 		      
 		<!-- Test Case 8.13: mixed subnode sets -->
 	    <!--   * allow (A,R) or (I,J,C) only    -->
-		<dm-mapping:COLLECTION dmrole="role">
-			<dm-mapping:ATTRIBUTE dmrole="A.b" dmtype="model:elem" value="foo" />
+		<dm-mapping:COLLECTION ID="id">
+			<dm-mapping:ATTRIBUTE  dmtype="model:elem" value="foo" />
 		</dm-mapping:COLLECTION>
 			
 		

--- a/schema/xsd/merged-syntax.xsd
+++ b/schema/xsd/merged-syntax.xsd
@@ -58,6 +58,8 @@ LM 2021-08-25: add VOtable import, prefix prefixes with dm-mapping
     </xs:sequence>
     <xs:attribute type="xs:string" name="tableref" />
     <xs:assert test="if (@tableref) then (@tableref != '') else true()  " />
+    <xs:assert test="every $child in ./dm-mapping:INSTANCE satisfies  $child/@dmrole != '' "/>
+    
   </xs:complexType>
 
 

--- a/schema/xsd/merged-syntax.xsd
+++ b/schema/xsd/merged-syntax.xsd
@@ -58,7 +58,7 @@ LM 2021-08-25: add VOtable import, prefix prefixes with dm-mapping
     </xs:sequence>
     <xs:attribute type="xs:string" name="tableref" />
     <xs:assert test="if (@tableref) then (@tableref != '') else true()  " />
-    <xs:assert test="every $child in ./dm-mapping:INSTANCE satisfies  $child/@dmrole != '' "/>
+    <xs:assert test="every $child in ./dm-mapping:INSTANCE satisfies  $child/@dmrole != '' or $child/@ID != '' "/>
     
   </xs:complexType>
 

--- a/schema/xsd/merged-syntax.xsd
+++ b/schema/xsd/merged-syntax.xsd
@@ -86,7 +86,7 @@ LM 2021-08-25: add VOtable import, prefix prefixes with dm-mapping
 
   <!-- Atomic attribute -->
   <xs:complexType name="Attribute">
-    <xs:attribute type="xs:string" name="dmrole" use="required" />
+    <xs:attribute type="xs:string" name="dmrole" use="optional" />
     <xs:attribute type="xs:string" name="dmtype" use="required" />
     <xs:attribute type="xs:string" name="ref" />
     <xs:attribute type="xs:string" name="value" />
@@ -96,7 +96,7 @@ LM 2021-08-25: add VOtable import, prefix prefixes with dm-mapping
     <xs:assert test="(not(./@ref) and ./@value) or (not(./@value) and ./@ref) or (./@value and ./@ref)" /> 
     <xs:assert test="if (@ref) then (@ref != '') else true()  " />  
     <xs:assert test="if (@arrayindex) then (@arrayindex >= '0') else true()  " />  
-    <xs:assert test="@dmrole != '' and @dmtype != ''  " />  
+    <xs:assert test="@dmtype != ''  " />  
   </xs:complexType>
 
   <!-- Data list mapping block -->
@@ -111,12 +111,15 @@ LM 2021-08-25: add VOtable import, prefix prefixes with dm-mapping
     <xs:attribute type="xs:string" name="dmrole" use="optional" />
     <xs:attribute type="xs:string" name="size" />  
     <xs:attribute type="xs:string" name="ID" />
-    <xs:assert test="(not(@ID) and @dmrole != '') or  @ID != ''" />
     <xs:assert test="if (@ID) then ( @ID != '') else true()  " />
     <xs:assert test="(count(dm-mapping:ATTRIBUTE) eq 0 and count(dm-mapping:REFERENCE) >= 0) or count(dm-mapping:ATTRIBUTE) > 0 and count(dm-mapping:REFERENCE) = 0"/>
     <xs:assert test="(count(dm-mapping:ATTRIBUTE) eq 0 and count(dm-mapping:INSTANCE) >= 0) or count(dm-mapping:ATTRIBUTE) > 0 and count(dm-mapping:INSTANCE) = 0"/>
     <xs:assert test="(count(dm-mapping:ATTRIBUTE) eq 0 and count(dm-mapping:JOIN) >= 0) or count(dm-mapping:ATTRIBUTE) > 0 and count(dm-mapping:JOIN) = 0"/>
     <xs:assert test="(count(dm-mapping:ATTRIBUTE) eq 0 and count(dm-mapping:COLLECTION) >= 0) or count(dm-mapping:ATTRIBUTE) > 0 and count(dm-mapping:COLLECTION) = 0"/>
+    <xs:assert test="count (dm-mapping:INSTANCE[@dmrole != '']) eq 0"/>
+    <xs:assert test="count (dm-mapping:ATTRIBUTE[@dmrole != '']) eq 0"/>
+    <xs:assert test="count (dm-mapping:COLLECTION[@dmrole != '']) eq 0"/>
+    <xs:assert test="count (dm-mapping:REFERENCE[@dmrole != '']) eq 0"/>
     
      <!-- 
     <xs:assert test="((count(./dm-mapping:JOIN) eq 1 and count(./dm-mapping:INSTANCE) eq 0 and count(./dm-mapping:COLLECTION) eq 0 and count(./dm-mapping:REFERENCE) eq 0)  or count(./dm-mapping:JOIN) eq 0)" />
@@ -127,11 +130,10 @@ LM 2021-08-25: add VOtable import, prefix prefixes with dm-mapping
     <xs:sequence>
       <xs:element name="FOREIGN_KEY" type="dm-mapping:ForeignKey" minOccurs="0" maxOccurs="unbounded" />
     </xs:sequence>
-    <xs:attribute type="xs:string" name="dmrole" use="required" />
+    <xs:attribute type="xs:string" name="dmrole" use="optional" />
     <xs:attribute type="xs:string" name="tableref" />
     <xs:attribute type="xs:string" name="dmref" />
     <xs:assert test="if (./@tableref) then  @tableref != '' else true()" />
-    <xs:assert test="./@dmrole and  @dmrole != ''" />
     <xs:assert test="if (./@dmref) then  @dmref != '' else true()" />
     <xs:assert test="(./@dmref and not(./@tableref)) or (not(./@dmref) and ./@tableref)" />    
     <xs:assert test="((count(dm-mapping:FOREIGN_KEY) > 0 and ./@tableref and not(./@dmref))  or (count(./dm-mapping:FOREIGN_KEY) eq 0 and not(./@tableref) and ./@dmref))" />

--- a/schema/xsd/merged-syntax.xsd
+++ b/schema/xsd/merged-syntax.xsd
@@ -82,6 +82,12 @@ LM 2021-08-25: add VOtable import, prefix prefixes with dm-mapping
     <!-- xs:assert test="(not(./@ID) and  @dmrole != '') or @ID != ''  " /> -->
     <xs:assert test=" @dmtype != '' " />
     <xs:assert test="if (@ID) then ( @ID != '') else true()  " />
+    <xs:assert test="every $child in ./dm-mapping:INSTANCE satisfies  $child/@dmrole != '' "/>
+    <xs:assert test="every $child in ./dm-mapping:COLLECTION satisfies  $child/@dmrole != '' "/>
+    <xs:assert test="every $child in ./dm-mapping:ATTRIBUTE satisfies  $child/@dmrole != '' "/>
+    <xs:assert test="every $child in ./dm-mapping:REFERENCE satisfies  $child/@dmrole != '' "/>
+    
+    
   </xs:complexType>
 
   <!-- Atomic attribute -->

--- a/schema/xsd/merged-syntax.xsd
+++ b/schema/xsd/merged-syntax.xsd
@@ -44,6 +44,10 @@ LM 2021-08-25: add VOtable import, prefix prefixes with dm-mapping
       <xs:element name="INSTANCE" type="dm-mapping:Instance" minOccurs="0" maxOccurs="unbounded" />
       <xs:element name="COLLECTION" type="dm-mapping:Collection" minOccurs="0" maxOccurs="unbounded" />
     </xs:all>
+    <xs:assert test="count (dm-mapping:INSTANCE[@dmrole != '']) eq 0"/>
+    <xs:assert test="every $child in ./dm-mapping:INSTANCE satisfies  $child/@ID != '' "/>
+    <xs:assert test="count (dm-mapping:COLLECTION[@dmrole != '']) eq 0"/>
+    <xs:assert test="every $child in ./dm-mapping:COLLECTION satisfies  $child/@ID != '' "/>
   </xs:complexType>
 
   <!-- Mapping of the data contained in a particular table -->
@@ -73,7 +77,7 @@ LM 2021-08-25: add VOtable import, prefix prefixes with dm-mapping
     <xs:attribute type="xs:string" name="dmrole" use="optional" /> 
     <xs:attribute type="xs:string" name="dmtype" use="required" /> 
     <xs:attribute type="xs:string" name="ID" />  
-    <xs:assert test="(not(./@ID) and  @dmrole != '') or @ID != ''  " />
+    <!-- xs:assert test="(not(./@ID) and  @dmrole != '') or @ID != ''  " /> -->
     <xs:assert test=" @dmtype != '' " />
     <xs:assert test="if (@ID) then ( @ID != '') else true()  " />
   </xs:complexType>
@@ -102,7 +106,7 @@ LM 2021-08-25: add VOtable import, prefix prefixes with dm-mapping
       <xs:element name="COLLECTION" type="dm-mapping:Collection" minOccurs="0"  />
       <xs:element name="JOIN" type="dm-mapping:Join" minOccurs="0" />
     </xs:choice>
-    <xs:attribute type="xs:string" name="dmrole" use="required" />
+    <xs:attribute type="xs:string" name="dmrole" use="optional" />
     <xs:attribute type="xs:string" name="size" />  
     <xs:attribute type="xs:string" name="ID" />
     <xs:assert test="(not(@ID) and @dmrole != '') or  @ID != ''" />


### PR DESCRIPTION
New ELEM/CHILD rules.

The constraints on the CHILDREN must be set at ELEM level.
This change has many side effects that have been checked (some may be missing)

The new rules are:

GLOBALS:
- allowed children: INSTANCE GLOBAL
- All children must have a non empty @ID
- All children must have no or empty @dmrole

TEMPLATES:
- Concerned child: INSTANCE
- Must have either a @dmrole or an non empty @ID 

COLLECTION:
- Concerned children: INSTANCE ATTRIBUTE COLLECTION REFERENCE
- Must have an empty @dmrole or no @dmrole

INSTANCE:
- Concerned children: INSTANCE ATTRIBUTE COLLECTION REFERENCE
- Must have a non empty @dmrole 

Rich VOTables do no pass the test meanwhile these new rules are validated.