### PR TITLE
Rule that the schema prevents COLLECTION to have others children than

### DIFF
--- a/doc/element_collection.tex
+++ b/doc/element_collection.tex
@@ -1,5 +1,7 @@
     COLLECTION is a container element.  It is used in different contexts, each allowing a limited subset of elements for its content. 
-
+    
+    COLLECTION can be populated either by a static list of items (INSTANCE, ATTRIBUTE,..) or by one JOIN operation. Both mode modes cannot coexist.
+    
     \begin{enumerate}
     \item{As child of INSTANCE}
       
@@ -50,6 +52,15 @@
     </dm-mapping:COLLECTION>
 <dm-mapping:GLOBALS>
 \end{lstlisting}   
+
+\begin{lstlisting}[frame=single,caption={Example of COLLECTION populated with a JOIN},style=XML,basicstyle=\tiny]
+<dm-mapping:GLOBALS>
+    <dm-mapping:COLLECTION dmrole="_joined_dataj">
+        <dm-mapping:JOIN tableref="_someTable" dmref="_extInst"/>
+    </dm-mapping:COLLECTION>
+<dm-mapping:GLOBALS>
+\end{lstlisting}   
+
 
 \begin{table}[!htbp]
   \small
@@ -106,7 +117,7 @@
     \hline 
       \textbf{Element} &
       \textbf{Position} &
-      \textbf{Occurs} &  \\
+      \textbf{Occurs}  \\
     \hline
     \hline  
         \texttt{ATTRIBUTE} & 
@@ -126,8 +137,8 @@
     \hline    
         \texttt{JOIN} & 
         Any & 
-        0-* & 
-        Collection populated with a set of joined instances.\\
+        0-1 & 
+        Collection populated with a set of joined instances. No other child is supported in this case\\
     \hline    
         \texttt{COLLECTION} & 
         Only & 
@@ -146,6 +157,11 @@
         Only & 
         0-* & 
         Collection of related instances.\\
+    \hline    
+        \texttt{REFERENCE} & 
+        Only & 
+        0-* & 
+        Collection of related references.\\
     \hline 
   \end{tabulary}
      \caption{Allowed children for \texttt{COLLECTION}} 

--- a/schema/validation/python/tests/test_8_collection.py
+++ b/schema/validation/python/tests/test_8_collection.py
@@ -30,7 +30,7 @@ expected = {
             '8.17': 'VALID',
             '8.18': 'VALID',
             '8.19': 'VALID',
-            '8.20': 'VALID',
+            '8.20': 'assertion test if false',
             '8.21': 'count(dm-mapping:ATTRIBUTE) gt 0 and',
             '8.22': 'count(dm-mapping:REFERENCE) gt 0 and',
             '8.23': 'count(dm-mapping:ATTRIBUTE) gt 0 and',

--- a/schema/validation/python/utils/validator.py
+++ b/schema/validation/python/utils/validator.py
@@ -19,6 +19,7 @@ class Validator:
                 self.xmlschema.validate(xml_path)
                 return True
             except Exception as e:
+                #print(e)
                 return self._errorMatchExpectedMessage(e, expected_fail_msg)
         else :
             return self.xmlschema.is_valid(xml_path)

--- a/schema/validation/snippets/test_8_ko_8.20.xml
+++ b/schema/validation/snippets/test_8_ko_8.20.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<dm-mapping:VODML
+	xmlns:dm-mapping="http://www.ivoa.net/xml/merged-syntax">
+
+	<dm-mapping:MODEL name="model" url="http://aaaaaa" />
+	<dm-mapping:GLOBALS>
+
+		<dm-mapping:INSTANCE dmid="_aaa" dmtype="model:thing">
+
+            <!-- Test Case 8.20: COLLECTION of INSTANCE + JOIN (local and external instances) -->
+            <dm-mapping:COLLECTION dmrole="iiiiii">
+                <dm-mapping:INSTANCE dmtype="model:object" />
+                <dm-mapping:JOIN tableref="_someTable" dmref="_extInst1"/>
+                <dm-mapping:JOIN tableref="_someOtherTable" dmref="_extInst2"/>
+                <dm-mapping:INSTANCE dmtype="model:object" />
+                <dm-mapping:INSTANCE dmtype="model:object" />
+            </dm-mapping:COLLECTION>
+			
+		</dm-mapping:INSTANCE>
+
+		
+	</dm-mapping:GLOBALS>
+</dm-mapping:VODML>
+
+
+

--- a/schema/validation/snippets/test_8_ok.xml
+++ b/schema/validation/snippets/test_8_ok.xml
@@ -78,15 +78,6 @@
 				<dm-mapping:JOIN tableref="_someTable" dmref="_extInst"/>
 			</dm-mapping:COLLECTION>
 
-			<!-- Test Case 8.20: COLLECTION of INSTANCE + JOIN (local and external instances) -->
-			<dm-mapping:COLLECTION dmrole="iiiiii">
-				<dm-mapping:INSTANCE dmtype="model:object" />
-				<dm-mapping:JOIN tableref="_someTable" dmref="_extInst1"/>
-				<dm-mapping:JOIN tableref="_someOtherTable" dmref="_extInst2"/>
-				<dm-mapping:INSTANCE dmtype="model:object" />
-				<dm-mapping:INSTANCE dmtype="model:object" />
-			</dm-mapping:COLLECTION>
-
 		</dm-mapping:INSTANCE>
 
 	</dm-mapping:GLOBALS>

--- a/schema/validation/snippets/test_rich_instance_ok_1.xml
+++ b/schema/validation/snippets/test_rich_instance_ok_1.xml
@@ -23,7 +23,7 @@
 							<dm-mapping:INSTANCE dmrole="test.owner" dmtype="test.Owner">
 								<dm-mapping:ATTRIBUTE dmrole="test.owner.name" dmtype="string" value="Michel" />
 								<dm-mapping:ATTRIBUTE dmrole="test.owner.firstname" dmtype="string" value="Laurent" />
-								<dm-mapping:ATTRIBUTE dmrole="test.title" dmtype="string" ref="_title" />
+								<dm-mapping:ATTRIBUTE dmrole="test.title" dmtype="string" value="TITLE" />
 							</dm-mapping:INSTANCE>
 							<dm-mapping:COLLECTION dmrole="test.points">
 								<dm-mapping:JOIN dmref="_point" tableref="Results" />
@@ -39,19 +39,11 @@
 							<dm-mapping:JOIN tableref="OtherResults">
 								<dm-mapping:WHERE primarykey="_poserr_148" foreignkey="_foreign" />
 							</dm-mapping:JOIN>
-							<dm-mapping:INSTANCE dmtype="test:Detection">
-								<dm-mapping:ATTRIBUTE dmrole="test:detection.num" dmtype="ivoa:real" ref="_num_148" />
-								<dm-mapping:ATTRIBUTE dmrole="test:detection.id" dmtype="ivoa:real" ref="_foreign" />
-							</dm-mapping:INSTANCE>
 						</dm-mapping:COLLECTION>
 						<dm-mapping:COLLECTION dmrole="test.spectra">
 							<dm-mapping:JOIN tableref="Spectra">
 								<dm-mapping:WHERE primarykey="_poserr_148" foreignkey="_foreign" />
 							</dm-mapping:JOIN>
-							<dm-mapping:INSTANCE dmtype="test:Detection">
-								<dm-mapping:ATTRIBUTE dmrole="test:detection.num" dmtype="ivoa:string" ref="_spc_148" />
-								<dm-mapping:ATTRIBUTE dmrole="test:detection.id" dmtype="ivoa:real" ref="_foreign" />
-							</dm-mapping:INSTANCE>
 						</dm-mapping:COLLECTION>
 					</dm-mapping:INSTANCE>
 				</dm-mapping:TEMPLATES>

--- a/schema/validation/snippets/test_rich_instance_ok_2.xml
+++ b/schema/validation/snippets/test_rich_instance_ok_2.xml
@@ -40,7 +40,7 @@
 								<dm-mapping:ATTRIBUTE
 									dmrole="test.owner.firstname" dmtype="string" value="Laurent" />
 								<dm-mapping:ATTRIBUTE dmrole="test.title"
-									dmtype="string" ref="_title" />
+									dmtype="string" value="TITLE" />
 							</dm-mapping:INSTANCE>
 							<dm-mapping:COLLECTION dmrole="test.points">
 								<dm-mapping:JOIN dmref="_point" tableref="Results" />
@@ -59,24 +59,12 @@
 								<dm-mapping:WHERE primarykey="_poserr_148"
 									foreignkey="_foreign" />
 							</dm-mapping:JOIN>
-							<dm-mapping:INSTANCE dmtype="test:Detection">
-								<dm-mapping:ATTRIBUTE
-									dmrole="test:detection.num" dmtype="ivoa:real" ref="_num_148" />
-								<dm-mapping:ATTRIBUTE
-									dmrole="test:detection.id" dmtype="ivoa:real" ref="_foreign" />
-							</dm-mapping:INSTANCE>
 						</dm-mapping:COLLECTION>
 						<dm-mapping:COLLECTION dmrole="test.spectra">
 							<dm-mapping:JOIN tableref="Spectra">
 								<dm-mapping:WHERE primarykey="_poserr_148"
 									foreignkey="_foreign" />
 							</dm-mapping:JOIN>
-							<dm-mapping:INSTANCE dmtype="test:Detection">
-								<dm-mapping:ATTRIBUTE
-									dmrole="test:detection.num" dmtype="ivoa:string" ref="_spc_148" />
-								<dm-mapping:ATTRIBUTE
-									dmrole="test:detection.id" dmtype="ivoa:real" ref="_foreign" />
-							</dm-mapping:INSTANCE>
 						</dm-mapping:COLLECTION>
 					</dm-mapping:INSTANCE>
 				</dm-mapping:TEMPLATES>

--- a/schema/xsd/merged-syntax.xsd
+++ b/schema/xsd/merged-syntax.xsd
@@ -173,7 +173,7 @@
 			<xs:element name="COLLECTION" type="dm-mapping:Collection"
 				minOccurs="0" />
 			<xs:element name="JOIN" type="dm-mapping:Join"
-				minOccurs="0" />
+				minOccurs="0" maxOccurs="1" />
 		</xs:choice>
 		<xs:attribute type="xs:string" name="dmrole"
 			use="optional" />
@@ -192,6 +192,15 @@
 			> 0 and count(dm-mapping:COLLECTION) = 0"/> -->
 		<!-- collection of (attribute)||(reference)||(instance+join)||(collection) -->
 		<!-- - contains some redundancies, but will work if order of checks changes -->
+		
+        <xs:assert
+            test="if (count(dm-mapping:JOIN) > 0 ) then (count(dm-mapping:REFERENCE) = 0) else true()" />
+        <xs:assert
+            test="if (count(dm-mapping:JOIN) > 0 ) then (count(dm-mapping:INSTANCE) = 0) else true()" />
+        <xs:assert
+            test="if (count(dm-mapping:JOIN) > 0 ) then (count(dm-mapping:ATTRIBUTE) = 0) else true()" />
+        <xs:assert
+            test="if (count(dm-mapping:JOIN) > 0 ) then (count(dm-mapping:COLLECTION) = 0) else true()" />
 		<xs:assert
 			test="count(dm-mapping:ATTRIBUTE) eq 0 or (count(dm-mapping:ATTRIBUTE) gt 0 and count(dm-mapping:REFERENCE) eq 0 and count(dm-mapping:INSTANCE) eq 0 and count(dm-mapping:JOIN) eq 0 and count(dm-mapping:COLLECTION) eq 0)" />
 		<xs:assert


### PR DESCRIPTION
No longer allow COLLECTION to have other children than one JOIN when present.
text/test/schema updated
fix #76 