### PR TITLE
change date for MT comment answer

### DIFF
--- a/doc/ivoatexmeta.tex
+++ b/doc/ivoatexmeta.tex
@@ -1,6 +1,6 @@
 % GENERATED FILE -- edit this in the Makefile
 \newcommand{\ivoaDocversion}{1.0}
-\newcommand{\ivoaDocdate}{2022-09-16}
-\newcommand{\ivoaDocdatecode}{20220916}
+\newcommand{\ivoaDocdate}{2022-10-05}
+\newcommand{\ivoaDocdatecode}{20221005}
 \newcommand{\ivoaDoctype}{PR}
 \newcommand{\ivoaDocname}{mivot}


### PR DESCRIPTION
This commit only changes the publication  date.
The other commits fixing the error pointed by @mbtaylor have been accidentally pushed on master.
You can see that by looking at the Oct 05 commits on that branch