### PR TITLE
Minor wording/typo changes

### DIFF
--- a/doc/element_attribute.tex
+++ b/doc/element_attribute.tex
@@ -7,6 +7,7 @@ the usage:
 
 \begin{enumerate}
 \item Child of \texttt{INSTANCE}
+
  The \texttt{ATTRIBUTE} can be seen as a class attribute;
     it must have a \texttt{@dmrole} XML attribute.
 
@@ -20,7 +21,8 @@ In this case, the \texttt{ATTRIBUTE} must be specified by:
   \end{itemize}  
 
   
-\item Child of \texttt{COLLECTION} 
+\item Child of \texttt{COLLECTION}
+
 In this case the host \texttt{COLLECTION} can be seen as a vector and the \texttt{ATTRIBUTE} as one coordinate of the vector. 
 It must have  no \texttt{@dmrole} XML attribute or an empty one.
 
@@ -39,7 +41,7 @@ In this case, the \texttt{ATTRIBUTE} must be specified by:
     If the \texttt{ATTRIBUTE}  is located within a \texttt{GLOBALS}, its value must be set with  a  \texttt{@value} since the \texttt{GLOBALS} block is not connected with any data table.
 \end{enumerate}  
  
- MIVOT does not specify the way the handle NULL values. This remains in charge of the client implementation, 
+ MIVOT does not specify the way to handle NULL values. This remains in charge of the client implementation, 
  not of the syntax. The role of syntax is to tell the client how to build model instances. 
  If a \texttt{@ref} points onto a null \texttt{FIELD} value, the client has to set the corresponding model leaf 
  as NULL as well, but the way it do it is very specific to both language and implementation choices.

--- a/doc/element_collection.tex
+++ b/doc/element_collection.tex
@@ -137,7 +137,7 @@
       3 &
       OPT& 
       NO & 
-      The element maps a collection within another \texttt{COLLECTION}.  \texttt{@dmrole} MUST not set or empty.  If present, \texttt{@dmid} MUST NOT be empty. \\
+      The element maps a collection within another \texttt{COLLECTION}.  \texttt{@dmrole} MUST be empty or not set.  If present, \texttt{@dmid} MUST NOT be empty. \\
     \hline 
   \end{tabulary}
   \caption{Valid XML attribute patterns for \texttt{COLLECTION}. } 

--- a/doc/element_instance.tex
+++ b/doc/element_instance.tex
@@ -35,7 +35,8 @@ the usage:
            \begin{itemize}
              \item must contain at least one \texttt{PRIMARY\_KEY} sub-element
              \item may have a  \texttt{@dmid} attribute, as possible target of \texttt{REFERENCE}              
-             \item must have no  \texttt{@dmrole} attribute or an empty one. \texttt{VODML} does set roles to particular collection items
+             \item must have no  \texttt{@dmrole} attribute or an empty one. VO-DML roles are not associated
+             with individual collection items.
            \end{itemize}
 
      \item each member \texttt{INSTANCE} is a cell of an element with multiplicity > 1.

--- a/doc/element_model.tex
+++ b/doc/element_model.tex
@@ -1,5 +1,5 @@
-A VOTable can provide serializations for an arbitrary number of data model
-types. In order to declare which models are represented in the file, data
+A VOTable can provide serializations for an arbitrary number of data models.
+In order to declare which models are represented in the file, data
 providers must declare them through the \texttt{MODEL} elements.
 All models that define vodml-ids used in the annotation must be declared.
 

--- a/doc/element_reference.tex
+++ b/doc/element_reference.tex
@@ -1,4 +1,4 @@
-INSTANCE reference that can be used with the same patterns as for \texttt{INSTANCE} .
+\texttt{INSTANCE} reference that can be used with the same patterns as for \texttt{INSTANCE} .
 There are different uses for the \texttt{REFERENCE} 
 
 \begin{itemize}

--- a/doc/introduction.tex
+++ b/doc/introduction.tex
@@ -45,6 +45,6 @@ As a consequence, an annotation mechanism such as MIVOT, based on VO-DML and pre
 The basis of MIVOT is to insert into the VOTable, an XML block complying with the 
 model structure and containing references to the actual data.
 These blocks are designed in such a way that a model-aware client can build  model instances by copying that structure and by resolving the references. 
-Other clients can just ignore them and rely as usual on the FIELD/PARAM and GROUP structures.
+Other clients can just ignore them and rely as usual on the \texttt{FIELD}/\texttt{PARAM} and \texttt{GROUP} structures.
 
 

--- a/doc/introduction.tex
+++ b/doc/introduction.tex
@@ -33,14 +33,14 @@ However, some UTypes features that could complicate the mapping process have bee
   (as TimeSeries or Catalog/Source for instance)
 \end{itemize}
 
-The UType approach could have been extended to overcome these limitations, but it has been decided to move forward a solution closer to the \texttt{VODML} \citep{2018ivoa.spec.0910L} concepts. 
-\texttt{VODML} is a meta-model that gives a standard way to express VO models as machine-readable XML document.
-In \texttt{VODML}, the role of model leaves are no longer given by simple strings like UTypes, but by the local role they play in the model hierarchy.
+The UType approach could have been extended to overcome these limitations, but it has been decided to move forward a solution closer to the VO-DML \citep{2018ivoa.spec.0910L} concepts. 
+VO-DML is a meta-model that gives a standard way to express VO models as machine-readable XML document.
+In VO-DML, the role of model leaves are no longer given by simple strings like UTypes, but by the local role they play in the model hierarchy.
 
 
 
 
-As a consequence, an annotation mechanism such as MIVOT, based on \texttt{VODML} and preserving the model hierarchy can easily provide data representations faithful to that model.
+As a consequence, an annotation mechanism such as MIVOT, based on VO-DML and preserving the model hierarchy can easily provide data representations faithful to that model.
 
 The basis of MIVOT is to insert into the VOTable, an XML block complying with the 
 model structure and containing references to the actual data.

--- a/doc/mivot.tex
+++ b/doc/mivot.tex
@@ -96,7 +96,7 @@
 \begin{document}
 
 \begin{abstract}
-Model Instances in VOTables (MIVOT) defines a syntax to map VOTable data to any model serizalized in VODML.
+Model Instances in VOTables (MIVOT) defines a syntax to map VOTable data to any model serizalized in VO-DML.
 The annotation operates as a bridge between the data and the model.
 It associates the column/param metadata from the VOTable to the 
 data model elements (class, attributes, types, etc.) of a standardized IVOA data model, expressed in the Virtual Observatory Data Modeling Language (here after VO-DML).

--- a/doc/requirements.tex
+++ b/doc/requirements.tex
@@ -25,7 +25,7 @@
   
   \item Model agnostic behavior:
   \begin {itemize}
-    \item The annotation syntax must be able to map data on any \texttt{VODML} compliant model
+    \item The annotation syntax must be able to map data on any VO-DML compliant model
     \item The annotation syntax must allow clients to use their own strategy to consume mapped data, so they could:
       \begin {itemize}
         \item just ignore it

--- a/doc/syntax.tex
+++ b/doc/syntax.tex
@@ -3,7 +3,7 @@
 The syntax has been designed %to use as few XML elements as possible and to rely on XML attributes to setup the element behavior in a particular context.
 as a restricted but still complete set of XML elements. It relies on XML attributes to setup the element behavior in a particular context.
 As shown in table \ref{tbl:syntax-ele} the mapping elements  are used %can be grouped 
-in three different scopes. There are only three elements for the models structure itself. We assume that any data hierarchy  can be represented by a combination of collections  \texttt{COLLECTION}, tuples  \texttt{INSTANCE}, and simple values  \texttt{ATTRIBUTE}. The others elements are either to set the mapping block structure or to connect data to each other.
+in three different scopes. There are only three elements for the models structure itself. We assume that any data hierarchy  can be represented by a combination of collections  \texttt{COLLECTION}, tuples  \texttt{INSTANCE}, and simple values  \texttt{ATTRIBUTE}. The other elements are either to set the mapping block structure or to connect data to each other.
 
 \begin{table}[!htbp]
 \small
@@ -41,7 +41,7 @@ As shown in Table \ref{tbl:syntax-att} and following the \texttt{VODML} pattern,
        \hline         
        \hline  
              Model related & 
-             \texttt{@name} \texttt{@uri} \\
+             \texttt{@name} \texttt{@url} \\
        \hline  
              Modeled node related & 
              \texttt{@dmrole} \texttt{@dmtype} \\
@@ -53,7 +53,7 @@ As shown in Table \ref{tbl:syntax-att} and following the \texttt{VODML} pattern,
              \texttt{@tableref} \texttt{@ref} \\
        \hline  
              Mapping element identification& 
-             \texttt{@dmref} \texttt{@dmid} \texttt{@url} \texttt{@sourceref} \texttt{@primarykey} \texttt{@foreignkey} \\
+             \texttt{@dmref} \texttt{@dmid} \texttt{@sourceref} \texttt{@primarykey} \texttt{@foreignkey} \\
        \hline
      \end{tabulary}
      \caption{Attributes of mapping elements grouped by scopes.} 


### PR DESCRIPTION
1. change "VODML" to "VO-DML" in plain text when referring to the standard.
2. minor wording/typo changes