### PR TITLE
TEMPLATES tableref attribute

### DIFF
--- a/doc/element_templates.tex
+++ b/doc/element_templates.tex
@@ -36,7 +36,7 @@ one for each row of the associated VOTable \texttt{TABLE}.  A subset of the asso
     \hline
     \hline  
          \texttt{@tableref} & 
-         ID of the mapped VOTable \texttt{TABLE}.\\
+         ID or name of the mapped VOTable \texttt{TABLE}. ID match takes precedence over name matches when resolving the reference. \\
     \hline 
   \end{tabulary}
   \caption{\texttt{TEMPLATES} attributes.} 


### PR DESCRIPTION
Allow VOTable TABLE  ID or name at TEMPLATES tableref attribute.
Matches recent update to ATTRIBUTE \@ref to allow ID or name of VOTable PARAM|FIELD.