### PR TITLE
Remove the following requirements: MIVOT first child of the

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -7,7 +7,7 @@ DOCNAME = mivot
 DOCVERSION = 1.0
 
 # Publication date, ISO format; update manually for "releases"
-DOCDATE = 2022-12-12
+DOCDATE = 2022-20-12
 
 # What is it you're writing: NOTE, WD, PR, REC, PEN, or EN
 DOCTYPE = PR

--- a/doc/appendix_A.tex
+++ b/doc/appendix_A.tex
@@ -11,6 +11,6 @@ data structure.
 Most of the XML snippets of the normative sections are taken out from this table. 
 In this case, links connecting the text with the relevant locations in the listing have been setup.
 
-The VOTabke below contains many comments explaining how mapping patterns must be interpreted.
+The VOTable below contains many comments explaining how mapping patterns must be interpreted.
 \lstinputlisting[caption={Gaia multiband example. Notice that due to a Latex tweak, all \_ characters are prefixed with a \textbackslash},language=XML,escapeinside={@}{@}]{appendix_A.xml}
 

--- a/doc/appendix_A.xml
+++ b/doc/appendix_A.xml
@@ -35,7 +35,6 @@
         <REPORT status="OK">Mapping compiled by hand</REPORT>
         <!-- @\label{MODEL_snippet}@ back to @\ref{MODEL}@ -->
         <MODEL name="ivoa"   url="https://www.ivoa.net/xml/VODML/IVOA-v1.vo-dml.xml" />
-        <MODEL name="ivoa"   url="https://www.ivoa.net/xml/VODML/IVOA-v1.vo-dml.xml" />
         <MODEL name="mango"  url="https://github.com/ivoa-std/MANGO/blob/master/vo-dml/mango.vo-dml.xml" />
         <MODEL name="cube"   url="https://github.com/ivoa-std/Cube/vo-dml/Cube-1.0.vo-dml.xml" />
         <MODEL name="ds"     url="https://github.com/ivoa-std/DatasetMetadata/vo-dml/DatasetMetadata-1.0.vo-dml.xml" />

--- a/doc/mivot.tex
+++ b/doc/mivot.tex
@@ -184,17 +184,19 @@ The data model annotation will reside within the scope of a VOTABLE V1.1+.
 
 The mapping block:
 \begin{itemize}
-\item MUST be contained in a VOTable RESOURCE with \texttt{type="meta"}. 
-      This extra feature is consistent with VOTable xml schema RESOURCE type definition and doesn't require any modification in the xml schema.
-\item which MUST be the first child of the RESOURCE containing the data to be annotated.
-\item there MUST be no more than one mapping block per 'results' RESOURCE.
+\item MUST be contained in a VOTable \texttt{RESOURCE} with \texttt{type="meta"}. 
+      This extra feature is consistent with VOTable xml schema \texttt{RESOURCE} type definition 
+      and doesn't require any modification in the xml schema.
+\item MUST be child of the \texttt{RESOURCE} containing the data to be annotated.
+\item MUST be unique in the \texttt{RESOURCE} containing the data to be annotated.
 \end{itemize}
 
-The scope of the mapping block is the whole content of the 'results' RESOURCE. \newline
+The scope of the mapping block is the whole content its parent \texttt{RESOURCE}. \newline
 
 \noindent \textbf{Namespace}
 
-The mapping element must be isolated from the VOTable elements by a name space set as an attribute of the \texttt{VODML} element.
+The mapping element must be isolated from the VOTable elements by a name space set 
+as an attribute of the \texttt{VODML} element.
 
 \begin{lstlisting}[caption={Mapping block in a VOTable},language=XML]
 <VOTABLE xmlns="http://www.ivoa.net/xml/VOTable/v1.3" 

--- a/doc/mivot.tex
+++ b/doc/mivot.tex
@@ -201,7 +201,7 @@ as an attribute of the \texttt{VODML} element.
 \begin{lstlisting}[caption={Mapping block in a VOTable},language=XML]
 <VOTABLE xmlns="http://www.ivoa.net/xml/VOTable/v1.3" 
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.3">
-  <RESOURCE type="results">
+  <RESOURCE>
     <RESOURCE type="meta">
       <VODML xmlns="http://www.ivoa.net/xml/mivot">
         ...
@@ -292,6 +292,9 @@ as an attribute of the \texttt{VODML} element.
 \item June 2022 (MR \#124): The \texttt{dm-mapping:} prefix in MIVOT element has been dropped. 
 \item December 2022 (MR \#173): Allow \texttt{ATTRIBUTE} located in the \texttt{GLOBALS} block 
       to refer to VOTable \texttt{PARAM}. 
+\item December 2022 (MR \#174): More flexible location of the MIVOT block.
+      It must be enclosed in a \texttt{RESOURCE@type=meta} which must be 
+      enclosed in another \texttt{RESOURCE}.
 
 The latest can however be traced from GitHub.
 \end{itemize}


### PR DESCRIPTION
More flexible location of the MIVOT block.
It must enclosed in a RESOURCE@type=meta which must be enclosed in another RESOURCE. 