### PR TITLE
Fix/issue 176

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -7,7 +7,7 @@ DOCNAME = mivot
 DOCVERSION = 1.0
 
 # Publication date, ISO format; update manually for "releases"
-DOCDATE = 2023-01-16
+DOCDATE = 2023-01-19
 
 # What is it you're writing: NOTE, WD, PR, REC, PEN, or EN
 DOCTYPE = PR

--- a/doc/element_attribute.tex
+++ b/doc/element_attribute.tex
@@ -89,6 +89,7 @@ In this case, the \texttt{ATTRIBUTE} must be specified by:
             \texttt{ATTRIBUTE} unit. Unit applicable to the attribute value which is given 
             by either \texttt{@value} or \texttt{@ref}. \texttt{@unit} must always 
             be compliant with VOUnit \citep{2014ivoa.spec.0523D}. 
+            Empty \texttt{@unit} must be ignored.
             If the attribute value is set by a resolved \texttt{@ref}, 
             \texttt{@unit} must be the VOUnit counterpart of the \texttt{FIELD} or \texttt{PARAM} unit;
             an error must be risen otherwise.\\

--- a/doc/mivot.tex
+++ b/doc/mivot.tex
@@ -296,7 +296,7 @@ as an attribute of the \texttt{VODML} element.
 \item December 2022 (MR \#174): More flexible location of the MIVOT block.
       It must be enclosed in a \texttt{RESOURCE@type=meta} which must be 
       enclosed in another \texttt{RESOURCE}.
-\item January 2023 (PR \#179): Refine the allowed locations for the MIVOT block according to the issue #176.
+\item January 2023 (PR \#179): Refine the allowed locations for the MIVOT block according to the issue \#176.
 
 The latest can however be traced from GitHub.
 \end{itemize}

--- a/doc/mivot.tex
+++ b/doc/mivot.tex
@@ -187,7 +187,8 @@ The mapping block:
 \item MUST be contained in a VOTable \texttt{RESOURCE} with \texttt{type="meta"}. 
       This extra feature is consistent with VOTable xml schema \texttt{RESOURCE} type definition 
       and doesn't require any modification in the xml schema.
-\item MUST be child of the \texttt{RESOURCE} containing the data to be annotated.
+\item MUST appear in the same parent \texttt{RESOURCE} as the mapped \texttt{TABLE}-s.
+\item SHOULD appear before the \texttt{TABLE} to enable streaming of MIVOT-mapped records.
 \item MUST be unique in the \texttt{RESOURCE} containing the data to be annotated.
 \end{itemize}
 
@@ -289,12 +290,13 @@ as an attribute of the \texttt{VODML} element.
 \item The standards has been published as an IVOA WD under the MIVOT name in April 2022 
       (\url{https://ivoa.net/documents/MIVOT/20220407/index.html}). 
       Since that time, most of the changes were focused on the unite tests, the text and the client code.
-\item June 2022 (MR \#124): The \texttt{dm-mapping:} prefix in MIVOT element has been dropped. 
-\item December 2022 (MR \#173): Allow \texttt{ATTRIBUTE} located in the \texttt{GLOBALS} block 
+\item June 2022 (PR \#124): The \texttt{dm-mapping:} prefix in MIVOT element has been dropped. 
+\item December 2022 (PR \#173): Allow \texttt{ATTRIBUTE} located in the \texttt{GLOBALS} block 
       to refer to VOTable \texttt{PARAM}. 
 \item December 2022 (MR \#174): More flexible location of the MIVOT block.
       It must be enclosed in a \texttt{RESOURCE@type=meta} which must be 
       enclosed in another \texttt{RESOURCE}.
+\item January 2023 (PR \#179): Refine the allowed locations for the MIVOT block according to the issue #176.
 
 The latest can however be traced from GitHub.
 \end{itemize}


### PR DESCRIPTION
This PR comes in response of #176.
The MIVOT block must be in a RESOURCE located in the RESOURCE where the mapped data are. The MIVOT RESOURCE should be before the mapped data.